### PR TITLE
BEHAVIOR: install style job in editable mode

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ComPWA/actions/pip-install@v1
         with:
+          editable: "yes"
           extras: sty
           python-version: ${{ inputs.python-version }}
       - name: Fetch pre-commit cache

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -64,8 +64,8 @@ jobs:
           fi
       - uses: ComPWA/actions/pip-install@v1
         with:
-          editable: "yes"
           additional-packages: tox
+          editable: "yes"
           extras: ${{ env.TEST_EXTRAS }}
           python-version: ${{ matrix.python-version }}
           specific-packages: ${{ inputs.specific-pip-packages }}


### PR DESCRIPTION
This is required in case there are local hooks that the checked repository provides itself. See for instance this error: https://github.com/ComPWA/repo-maintenance/actions/runs/4032117575/attempts/3