### PR TITLE
FIX: run pip upgrade job on `ubuntu-20.04`

### DIFF
--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -29,7 +29,7 @@ jobs:
     name: Update pip constraints
     needs:
       - create-matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.create-matrix.outputs.matrix) }}


### PR DESCRIPTION
Python 3.6 can only be installed on `ubuntu-20.04`. See this [error](https://github.com/ComPWA/qrules/actions/runs/4032828219/jobs/6932953999).