### PR TITLE
FIX: specify `environment` for page deployement

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -33,6 +33,9 @@ jobs:
 
   gh-pages:
     name: Upload to GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     if: inputs.gh-pages && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     needs:
       - docnb
@@ -42,4 +45,5 @@ jobs:
       id-token: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/deploy-pages@v1
+      - id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
The [`environment`]() key was not set for the job that uses [`actions/deploy-pages`](https://github.com/actions/deploy-pages), see [this log](https://github.com/ComPWA/ampform-dpd/actions/runs/4034274609/jobs/6935411581).