### PR TITLE
FIX: remove `name` from artifact

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -73,7 +73,6 @@ jobs:
       - if: always() && steps.diff.outputs.diff != ''
         uses: actions/upload-artifact@v3
         with:
-          name: diff
           path: ${{ steps.diff.outputs.diff }}
 
   taplo:
@@ -104,7 +103,6 @@ jobs:
       - if: always() && steps.diff.outputs.diff != ''
         uses: actions/upload-artifact@v3
         with:
-          name: diff
           path: ${{ steps.diff.outputs.diff }}
 
   push:
@@ -124,7 +122,6 @@ jobs:
           token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
       - uses: actions/download-artifact@v3
         with:
-          name: diff
           path: .
       - if: always()
         name: Push changes


### PR DESCRIPTION
The push job in the `pre-commit` workflow crashes when the pre-commit hooks do not modify code. This PR fixes that.

![image](https://user-images.githubusercontent.com/29308176/236947303-81236d24-e582-4ff8-8305-fc3f52a269f7.png)
