### PR TITLE
FIX: determine if repository is Python package

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -40,11 +40,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - uses: ComPWA/actions/pip-install@v1
+      - name: Determine if repository is Python package
+        run: |
+          is_package=$(pip install . &> /dev/null && echo yes || echo no)
+          echo "IS_PYPI_PACKAGE=$is_package" | tee -a "$GITHUB_OUTPUT"
+        id: package
+      - if: ${{ steps.package.outputs.IS_PYPI_PACKAGE == 'yes' }}
+        uses: ComPWA/actions/pip-install@v1
         with:
           editable: "yes"
           extras: sty
           python-version: ${{ inputs.python-version }}
+      - if: ${{ steps.package.outputs.IS_PYPI_PACKAGE == 'no' }}
+        run: pip install pre-commit
       - name: Fetch pre-commit cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
If a repository contains a `.pre-commit-config.yaml`, it should be possible to run the `pre-commit.yml` workflow without the repository being a Python package (providing `sty` section for optional dependencies). See [this log](https://github.com/ComPWA/.github-private/actions/runs/6436936430/job/17481777166) for the testing. This PR installs `pre-commit` directly if the repo is not a Pythobn package.