### PR TITLE
FIX: run tes `pip install` statement with `-e` flag

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -40,9 +40,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ inputs.python-version }}
       - name: Determine if repository is Python package
         run: |
-          is_package=$(pip install -e . --user > /dev/null && echo yes || echo no)
+          is_package=$(pip install -e . > /dev/null && echo yes || echo no)
           echo "IS_PYPI_PACKAGE=$is_package" | tee -a "$GITHUB_OUTPUT"
         id: package
       - if: ${{ steps.package.outputs.IS_PYPI_PACKAGE == 'yes' }}


### PR DESCRIPTION
#35 introduced a small bug because the test step installs the package in a non-editable mode, whereas the `pre-commit` step does install in editable mode. This PR fixes that and also improves some of the diff and stderr output.