### PR TITLE
ENH: add `.gitignore` in `.constraints` directory

### DIFF
--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -70,6 +70,9 @@ jobs:
             ls -A
             [[ -f .pre-commit-config.yaml ]] && mv -f .pre-commit-config.yaml ..
             [[ "$(ls)" != "" ]] && mkdir -p ../.constraints/ && mv -f * ../.constraints/
+            cd ../.constraints/
+            [[ ! -f .gitignore ]] && echo '!py3.*.txt' > .gitignore
+            cd ../
           fi
       - run: git status -s
       - name: Commit and push changes


### PR DESCRIPTION
In https://github.com/ComPWA/strong2020-salamanca/pull/31, there is a `.gitignore` that ignores `*.txt` files, which caused the upgrade job to commit new pip constraint files. This PR should avoid that in the future by committing a `.gitignore` _into_ the `.constraints/` directory that undoes this `*.txt` ignore pattern.