### PR TITLE
DX: set `PRETTIER_LEGACY_CLI` when Prettier v4 alpha

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -161,6 +161,7 @@ jobs:
             git remote set-url origin https://x-access-token:${{ secrets.token }}@github.com/${{ github.repository }}
             git config user.name "GitHub"
             git config user.email "noreply@github.com"
+            git checkout -b ${{ github.head_ref }}
             git add -A
             git commit -m "MAINT: implement updates from pre-commit hooks"
             git config pull.rebase true


### PR DESCRIPTION
In accordance with https://github.com/ComPWA/repo-maintenance/pull/233, set [`PRETTIER_LEGACY_CLI=1`](https://prettier.io/blog/2023/11/30/cli-deep-dive#installation) when running pre-commit if the Prettier hook is run with Prettier v4-alpha.