### PR TITLE
FIX: upload to different artifact names

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -131,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: pre-commit-changes
+          name: pre-commit-changes-taplo
           path: ${{ steps.diff.outputs.diff }}
 
   push:
@@ -151,8 +151,9 @@ jobs:
           token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
       - uses: actions/download-artifact@v4
         with:
-          name: pre-commit-changes
+          merge-multiple: true
           path: .
+          pattern: pre-commit-changes*
       - if: always()
         name: Push changes
         run: |

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -36,7 +36,7 @@ jobs:
       matrix: ${{ fromJSON(needs.create-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
-      - uses: ComPWA/update-pip-constraints@main
+      - uses: ComPWA/update-pip-constraints@v1
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -62,6 +62,9 @@ jobs:
         with:
           token: ${{ secrets.token }}
       - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: artifact
       - run: ls -A
       - name: Move artifacts to correct location
         run: |


### PR DESCRIPTION
See https://github.com/ComPWA/update-pip-constraints/pull/17 and [`actions/upload-artifact` v4 migration guide](https://github.com/actions/upload-artifact/blob/v4.1.0/docs/MIGRATION.md\#multiple-uploads-to-the-same-named-artifact).