### PR TITLE
ENH: abort requirements PR creation if already existing

### DIFF
--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -82,10 +82,10 @@ jobs:
         run: |
           prs="${{ steps.list-prs.outputs.prs }}"
           if [[ -z "$prs" ]]; then
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "exists=false" | tee -a "$GITHUB_OUTPUT"
             echo "✅ No PR with title '${{ env.COMMIT_TITLE }}' found."
-            else
-            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=true" | tee -a "$GITHUB_OUTPUT"
             echo "❌ PR with title '${{ env.COMMIT_TITLE }}' already exists."
           fi
 


### PR DESCRIPTION
Avoid creating a PR that upgrades the lock files if there already exists an open PR that does that (has the same title). See for instance https://github.com/ComPWA/qrules/pull/257, which should not have been created, because https://github.com/ComPWA/qrules/pull/256 already existed.