### PR TITLE
ENH: print colors in output of pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -35,6 +35,7 @@ jobs:
     env:
       FORCE_COLOR: 1
       SKIP: taplo
+      TERM: xterm-256color
     if: >-
       ${{ needs.determine-hooks.outputs.skipped-hooks != '' && needs.determine-hooks.outputs.skipped-hooks != 'taplo' }}
     needs: determine-hooks


### PR DESCRIPTION
Compare [old output](https://github.com/ComPWA/update-pip-constraints/actions/runs/8247974892/job/22557529595?pr=23#step:9:30) with [new output](https://github.com/ComPWA/update-pip-constraints/actions/runs/8247974892/job/22557709230?pr=23#step:9:31).