### PR TITLE
ENH: show diff of lock files before push

### DIFF
--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -90,8 +90,6 @@ jobs:
           fi
 
   push:
-    env:
-      TERM: xterm-256color
     name: Push changes
     runs-on: ubuntu-22.04
     needs:
@@ -119,9 +117,11 @@ jobs:
             cd ../
           fi
       - name: Show changed files
-        run: git status --short
+        run: |
+          git config --global color.ui always
+          git status --short
       - name: Show changes
-        run: git diff --unified=0
+        run: git diff --color --unified=0
       - name: Commit and push changes
         if: github.event_name == 'pull_request'
         run: |


### PR DESCRIPTION
- The [ComPWA/actions/.github/workflows/requirements.yml@v1](https://github.com/ComPWA/actions/blob/v1/.github/workflows/requirements.yml) now shows the diff of the changes it pushes
- Pinned the [ComPWA/update-pre-commit](https://github.com/ComPWA/update-pre-commit) to [`v1`](https://github.com/ComPWA/update-pre-commit/releases/tag/1.0.0).