### PR TITLE
FIX: allow running `tox -e doc` jobs

### DIFF
--- a/.github/workflows/docnb.yml
+++ b/.github/workflows/docnb.yml
@@ -45,9 +45,10 @@ jobs:
           ijulia: true
       - name: Build documentation and run notebooks
         env:
+          EXECUTE_NB: yes
           GITHUB_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: tox -e docnb
+        run: tox -e doc
       - uses: actions/upload-pages-artifact@v3
         if: always()
         with:


### PR DESCRIPTION
_This PR is motivated by https://github.com/ComPWA/policy/pull/370_

Repositories currently need to define a `docnb` job, but this is not always needed, as some repositories do not have notebooks. This PR runs the `doc` job (which is always defined) and sets `EXECUTE_NB` externally.