### PR TITLE
BEHAVIOR: switch to `macos-14` runner

### DIFF
--- a/create-pytest-matrix/main.py
+++ b/create-pytest-matrix/main.py
@@ -75,7 +75,7 @@ def create_job_matrix(
     if macos_python_version:
         includes.append({
             "python-version": macos_python_version,
-            "runs-on": "macos-12",
+            "runs-on": "macos-14",
         })
     matrix = {}
     if python_versions:


### PR DESCRIPTION
`macos-latest` has been `macos-14` for some time now, see https://github.com/actions/runner-images?tab=readme-ov-file#available-images.