### PR TITLE
FIX: set `DISABLE_PRE_COMMIT_UV_PATCH=True`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,6 +17,9 @@ on:
           https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
         required: false
 
+env:
+  DISABLE_PRE_COMMIT_UV_PATCH: True
+
 jobs:
   determine-hooks:
     name: Determine skipped pre-commit hooks


### PR DESCRIPTION
Fix for https://github.com/ComPWA/policy/issues/407. Unfortunately, it seems that `pre-commit` with `uv` as backend does not yet work well on GitHub Actions.