### PR TITLE
ENH: remove `toml` dependency

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -41,7 +41,15 @@
     ".vscode/*",
     "pyproject.toml"
   ],
-  "ignoreWords": ["elif", "mhutchie", "noqa", "noreply", "taplo", "tomlkit"],
+  "ignoreWords": [
+    "elif",
+    "mhutchie",
+    "noqa",
+    "noreply",
+    "taplo",
+    "tomlkit",
+    "tomllib"
+  ],
   "language": "en-US",
   "version": "0.2",
   "words": []

--- a/create-pytest-matrix/action.yml
+++ b/create-pytest-matrix/action.yml
@@ -35,8 +35,6 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
-    - run: pip install toml
-      shell: bash
     - id: set-matrix
       name: Create run matrix in JSON form
       run: |

--- a/create-pytest-matrix/main.py
+++ b/create-pytest-matrix/main.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import json
 import os
+import tomllib
 from argparse import ArgumentParser
 from configparser import ConfigParser
 from typing import TYPE_CHECKING
-
-import toml
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -130,8 +129,8 @@ def __get_classifiers_from_cfg(path: str) -> list[str]:
 
 
 def __get_classifiers_from_toml(path: str) -> list[str]:
-    with open(path) as f:
-        cfg = toml.load(f)
+    with open(path, "rb") as f:
+        cfg = tomllib.load(f)
     classifiers = cfg.get("project", {}).get("classifiers")
     if classifiers is None:
         raise ValueError(CLASSIFIERS_ERROR_MSG)

--- a/create-python-version-matrix/action.yml
+++ b/create-python-version-matrix/action.yml
@@ -31,8 +31,6 @@ runs:
     - uses: actions/setup-python@v5
       with:
         python-version: "3.12"
-    - run: pip install toml
-      shell: bash
     - id: set-matrix
       name: Create run matrix in JSON form
       run: |

--- a/create-python-version-matrix/main.py
+++ b/create-python-version-matrix/main.py
@@ -2,9 +2,8 @@
 
 import json
 import os
+import tomllib
 from configparser import ConfigParser
-
-import toml
 
 PYPROJECT_TOML = "pyproject.toml"
 SETUP_CFG = "setup.cfg"
@@ -52,8 +51,8 @@ def __get_classifiers_from_cfg(path: str) -> list[str]:
 
 
 def __get_classifiers_from_toml(path: str) -> list[str]:
-    with open(path) as f:
-        cfg = toml.load(f)
+    with open(path, "rb") as f:
+        cfg = tomllib.load(f)
     classifiers = cfg.get("project", {}).get("classifiers")
     if classifiers is None:
         raise ValueError(CLASSIFIERS_ERROR_MSG)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python",
 ]
-dependencies = ["toml"]
 description = "Python scripts used by the ComPWA/actions repository"
 dynamic = ["version"]
 license = {text = "License :: OSI Approved :: MIT License"}


### PR DESCRIPTION
As a follow-up to #90, the [`toml`](https://pypi.org/project/toml) dependency has been replaced with the built-in [`tomllib`](https://docs.python.org/3/library/tomllib.html), which is available since Python 3.11.