### PR TITLE
ENH: remove `tomllkit` dependency

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -48,7 +48,6 @@
     "noreply",
     "pyright",
     "taplo",
-    "tomlkit",
     "tomllib"
   ],
   "language": "en-US",

--- a/get-pypi-name/action.yml
+++ b/get-pypi-name/action.yml
@@ -21,8 +21,6 @@ runs:
         curl -LsSf https://astral.sh/uv/install.sh | sh
         source $HOME/.cargo/env
       shell: bash
-    - run: uv pip install --color=always --system tomlkit
-      shell: bash
     - id: determine-name
       name: Determine Python package name
       run: |

--- a/get-pypi-name/main.py
+++ b/get-pypi-name/main.py
@@ -1,9 +1,8 @@
 """Print job matrix for a GitHub Actions workflow that runs `pytest`."""
 
 import os
+import tomllib
 from configparser import ConfigParser
-
-import tomlkit
 
 
 def main() -> int:
@@ -29,8 +28,8 @@ def _get_package_name_setup_cfg() -> str | None:
 def _get_package_name_pyproject_toml() -> str | None:
     if not os.path.exists("pyproject.toml"):
         return None
-    with open("pyproject.toml") as f:
-        pyproject = tomlkit.load(f)
+    with open("pyproject.toml", "rb") as f:
+        pyproject = tomllib.load(f)
     return pyproject.get("project", {}).get("name")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,8 @@ dev = [
     "compwa-actions[sty]",
 ]
 sty = [
-    "compwa-actions[types]",
     "pre-commit",
     "ruff",
-]
-types = [
-    "tomlkit",
 ]
 
 [project.readme]


### PR DESCRIPTION
Follow-up to #90 and #91. Removes the `pip install` step in the `get-pypi-name` step.