### PR TITLE
FIX: force `uv run` on Python 3.12

### DIFF
--- a/create-pytest-matrix/action.yml
+++ b/create-pytest-matrix/action.yml
@@ -43,7 +43,7 @@ runs:
       run: |
         delimiter="$(openssl rand -hex 8)"
         echo "matrix<<${delimiter}" >> $GITHUB_OUTPUT
-        uv run $GITHUB_ACTION_PATH/main.py \
+        uv run -p3.12 $GITHUB_ACTION_PATH/main.py \
           '${{ inputs.coverage-python-version }}' \
           '${{ inputs.coverage-target }}' \
           '${{ inputs.macos-python-version }}' \

--- a/create-python-version-matrix/action.yml
+++ b/create-python-version-matrix/action.yml
@@ -39,6 +39,6 @@ runs:
       run: |
         delimiter="$(openssl rand -hex 8)"
         echo "matrix<<${delimiter}" >> $GITHUB_OUTPUT
-        uv run $GITHUB_ACTION_PATH/main.py | tee -a $GITHUB_OUTPUT
+        uv run -p3.12 $GITHUB_ACTION_PATH/main.py | tee -a $GITHUB_OUTPUT
         echo "${delimiter}" >> $GITHUB_OUTPUT
       shell: bash

--- a/get-pre-commit-taplo-version/action.yml
+++ b/get-pre-commit-taplo-version/action.yml
@@ -23,5 +23,5 @@ runs:
       id: taplo
       name: Determine taplo version
       run: |
-        echo "version=$(uv run $GITHUB_ACTION_PATH/main.py)" | tee -a $GITHUB_OUTPUT
+        echo "version=$(uv run -p3.12 $GITHUB_ACTION_PATH/main.py)" | tee -a $GITHUB_OUTPUT
       shell: bash

--- a/get-skipped-pre-commit-hooks/action.yml
+++ b/get-skipped-pre-commit-hooks/action.yml
@@ -24,5 +24,5 @@ runs:
       id: set-hooks
       name: Determine skipped hooks
       run: |
-        echo "hooks=$(uv run $GITHUB_ACTION_PATH/main.py)" | tee -a $GITHUB_OUTPUT
+        echo "hooks=$(uv run -p3.12 $GITHUB_ACTION_PATH/main.py)" | tee -a $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
Fix-up after #94 
If the action is run with `actions/checkout` and a `.python-version` file is available, `uv run` picks up the pinned Python version from the repository.