### PR TITLE
ENH: set `FORCE_COLOR`

### DIFF
--- a/.github/workflows/docnb.yml
+++ b/.github/workflows/docnb.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Build documentation and run notebooks
         env:
           EXECUTE_NB: yes
+          FORCE_COLOR: yes
           GITHUB_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYTHONWARNINGS: ""

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -26,4 +26,5 @@ jobs:
           sudo apt-get install -y ${{ inputs.apt-packages }}
       - run: tox -e linkcheck
         env:
+          FORCE_COLOR: yes
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Run `tox -e doc` and `tox -e linkcheck` with `FORCE_COLOR=true`. This is needed since `FORCE_COLOR` was removed from `tox` `setenv` in https://github.com/ComPWA/policy/issues/408.