### PR TITLE
FIX: add `--no-dev` flag if using `--group` flag

### DIFF
--- a/.github/workflows/docnb.yml
+++ b/.github/workflows/docnb.yml
@@ -56,6 +56,7 @@ jobs:
         run: >-
           uv run \
             --group doc \
+            --no-dev \
             --with tox \
             tox -e doc
       - if: hashFiles('docs/_build/html')

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -36,5 +36,6 @@ jobs:
         run: >-
           uv run \
             --group doc \
+            --no-dev \
             --with tox \
             tox -e linkcheck

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -53,7 +53,7 @@ jobs:
           enable-cache: true
       - name: Determine if repository is Python package
         run: |
-          uv_command=$(uv pip install -e '.[sty]' > /dev/null && uv sync --group style && echo "uv run --group style" || echo uvx)
+          uv_command=$(uv pip install -e '.[sty]' > /dev/null && uv sync --group style --no-dev && echo "uv run --group style --no-dev" || echo uvx)
           echo "UV_COMMAND=$uv_command" | tee -a "$GITHUB_ENV"
       - name: Fetch pre-commit cache
         uses: actions/cache@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -101,6 +101,7 @@ jobs:
           uv run \
             --group test \
             ${{ steps.extra.outputs.extras }} \
+            --no-dev \
             ${{ steps.with.outputs.packages }} \
             pytest \
               ${{ steps.coverage.outputs.flags }} \


### PR DESCRIPTION
`uv run` and `uv sync` install all dependency groups by default. To limit the dependencies per job, this adds the [`--no-dev` flag](https://docs.astral.sh/uv/reference/cli/#uv-run).

_See also https://github.com/ComPWA/policy/pull/460_