### PR TITLE
FIX: run `pre-commit` with repo tags for `uv.lock`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
Fixes a problem like this
https://github.com/ComPWA/tensorwaves/pull/537/commits/04db2ebbd1f6f84aeab277d77f11d8a87fc6db07