### PR TITLE
ENH: run documentation tests with `tox-uv`

### DIFF
--- a/.github/workflows/docnb.yml
+++ b/.github/workflows/docnb.yml
@@ -53,7 +53,7 @@ jobs:
           uv run \
             --group doc \
             --no-dev \
-            --with tox \
+            --with tox-uv \
             tox -e doc
       - if: hashFiles('docs/_build/html')
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -34,5 +34,5 @@ jobs:
           uv run \
             --group doc \
             --no-dev \
-            --with tox \
+            --with tox-uv \
             tox -e linkcheck


### PR DESCRIPTION
This PR is required for https://github.com/ComPWA/policy/issues/496. It fixes this problem:
https://github.com/ComPWA/policy/actions/runs/12906564475/attempts/1?pr=498