### PR TITLE
ENH: update SymPy cache on changes to ipynb

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -45,6 +45,7 @@
   ],
   "ignoreWords": [
     "elif",
+    "ipynb",
     "mhutchie",
     "noqa",
     "noreply",

--- a/cache-sympy/action.yml
+++ b/cache-sympy/action.yml
@@ -16,7 +16,7 @@ runs:
       uses: actions/cache@v4
       with:
         key: |
-          sympy-${{github.job}}-${{hashFiles('.constraints/py3.*.txt', 'uv.lock')}}-${{hashFiles('src/**.py')}}
+          sympy-${{github.job}}-${{hashFiles('.constraints/py3.*.txt', 'uv.lock')}}-${{hashFiles('**/*.ipynb', '**/*.py')}}
         restore-keys: |
           sympy-${{github.job}}-${{hashFiles('.constraints/py3.*.txt', 'uv.lock')}}
           sympy-${{github.job}}


### PR DESCRIPTION
The SymPy cache is now updated if notebooks are updated. Previously this was only the case for Python scripts.