### PR TITLE
FIX: install `tox-uv` as tool instead of using `--with`

### DIFF
--- a/.github/workflows/docnb.yml
+++ b/.github/workflows/docnb.yml
@@ -49,11 +49,11 @@ jobs:
         with:
           ijulia: true
       - name: Build documentation and run notebooks
-        run: >-
+        run: |-
+          uv tool install --with tox-uv tox
           uv run \
             --group doc \
             --no-dev \
-            --with tox-uv \
             tox -e doc
       - if: hashFiles('docs/_build/html')
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -30,9 +30,9 @@ jobs:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Run Sphinx linkcheck
-        run: >-
+        run: |-
+          uv tool install --with tox-uv tox
           uv run \
             --group doc \
             --no-dev \
-            --with tox-uv \
             tox -e linkcheck


### PR DESCRIPTION
With newer versions of `uv`, running `uv run --with tox-uv tox ...` does not work well anymore on GitHub Actions.