### PR TITLE
FIX: run `tox-uv` through `uv run --with` again

### DIFF
--- a/.github/workflows/docnb.yml
+++ b/.github/workflows/docnb.yml
@@ -49,11 +49,11 @@ jobs:
         with:
           ijulia: true
       - name: Build documentation and run notebooks
-        run: |-
-          uv tool install --with tox-uv tox
+        run: >-
           uv run \
             --group doc \
             --no-dev \
+            --with tox-uv \
             tox -e doc
       - if: hashFiles('docs/_build/html')
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -30,9 +30,9 @@ jobs:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         name: Run Sphinx linkcheck
-        run: |-
-          uv tool install --with tox-uv tox
+        run: >-
           uv run \
             --group doc \
             --no-dev \
+            --with tox-uv \
             tox -e linkcheck


### PR DESCRIPTION
Reverts ComPWA/actions#139. See https://github.com/ComPWA/policy/pull/518#issuecomment-3117142127